### PR TITLE
Fix typo and add documentation

### DIFF
--- a/src/mintpy/asc_desc2horz_vert.py
+++ b/src/mintpy/asc_desc2horz_vert.py
@@ -170,7 +170,7 @@ def run_asc_desc2horz_vert(inps):
     lon_step = float(atr_list[0]['X_STEP'])
     length = int(round((S - N) / lat_step))
     width  = int(round((E - W) / lon_step))
-    print(f'overlaping area in SNWE: {(S, N, W, E)}')
+    print(f'overlapping area in SNWE: {(S, N, W, E)}')
 
 
     ## 2. read LOS data and geometry

--- a/src/mintpy/tsview.py
+++ b/src/mintpy/tsview.py
@@ -21,6 +21,21 @@ from mintpy.utils import plot as pp, ptime, readfile, time_func, utils as ut
 
 ###########################################################################################
 def read_init_info(inps):
+    """Read and initialize metadata and parameters.
+
+    Parameters
+    ----------
+    inps : Namespace
+        Input arguments from the command line parser.
+
+    Returns
+    -------
+    inps : Namespace
+        Updated input arguments with additional attributes.
+    atr : dict
+        Metadata dictionary of the first input file.
+    """
+
     # Time Series Info
     atr = readfile.read_attribute(inps.file[0])
     atr['DATA_TYPE'] = atr.get('DATA_TYPE', 'float32')
@@ -364,6 +379,8 @@ def read_timeseries_data(inps):
 
 
 def plot_ts_errorbar(ax, dis_ts, inps, ppar):
+    """Plot displacement time series with error bars."""
+
     # make a local copy
     dates = np.array(inps.dates)
     d_ts = dis_ts[:]
@@ -405,6 +422,8 @@ def plot_ts_errorbar(ax, dis_ts, inps, ppar):
 
 
 def plot_ts_scatter(ax, dis_ts, inps, ppar):
+    """Plot displacement time series as a scatter plot."""
+
     # make a local copy
     dates = np.array(inps.dates)
     d_ts = dis_ts[:]


### PR DESCRIPTION
## Summary
- fix overlapping typo in `asc_desc2horz_vert.py`
- add docstrings for initialization and plotting helpers in `tsview.py`

## Testing
- `pre-commit run --files src/mintpy/asc_desc2horz_vert.py src/mintpy/tsview.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ae9337c08320ab51057a9b9a795e